### PR TITLE
Inlude NetEvents Project into a Wetstone

### DIFF
--- a/Network/Events/AbstractEventArgs.cs
+++ b/Network/Events/AbstractEventArgs.cs
@@ -1,0 +1,6 @@
+namespace Wetstone.Network.Events;
+
+public abstract class AbstractEventArgs
+{
+    public bool Cancelled { get; set; } = false;
+}

--- a/Network/Events/AbstractIncomingEventArgs.cs
+++ b/Network/Events/AbstractIncomingEventArgs.cs
@@ -1,0 +1,8 @@
+using Unity.Entities;
+
+namespace Wetstone.Network.Events;
+
+public abstract class AbstractIncomingEventArgs : AbstractEventArgs
+{
+    public Entity UserEntity { get; internal set; }
+}

--- a/Network/Events/EventDirection.cs
+++ b/Network/Events/EventDirection.cs
@@ -1,0 +1,13 @@
+namespace Wetstone.Network.Events;
+
+public enum EventDirection
+{
+    /// <summary>
+    /// This is an incoming event, it is sent from the client to the server.
+    /// </summary>
+    ClientServer,
+    /// <summary>
+    /// This is an outgoing event, it is sent from the server to the client.
+    /// </summary>
+    ServerClient
+}

--- a/Network/Events/Incoming/ActivateVBloodAbility/ActivateVBloodAbilityEventArgs.cs
+++ b/Network/Events/Incoming/ActivateVBloodAbility/ActivateVBloodAbilityEventArgs.cs
@@ -1,0 +1,15 @@
+using ProjectM;
+
+namespace Wetstone.Network.Events;
+
+public class ActivateVBloodAbilityEventArgs : AbstractIncomingEventArgs
+{
+    public PrefabGUID AbilityGUID { get; }
+    public bool PrimarySlot { get; }
+
+    internal ActivateVBloodAbilityEventArgs(PrefabGUID abilityGUID, bool primarySlot)
+    {
+        AbilityGUID = abilityGUID;
+        PrimarySlot = primarySlot;
+    }
+}

--- a/Network/Events/Incoming/ActivateVBloodAbility/ActivateVBloodAbilityEventFactory.cs
+++ b/Network/Events/Incoming/ActivateVBloodAbility/ActivateVBloodAbilityEventFactory.cs
@@ -1,0 +1,23 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.ActivateVBloodAbility;
+
+internal class ActivateVBloodAbilityEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "ActivateVBloodAbilityEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var prefabGUID = networkEvent.NetBufferIn.ReadPrefabGUID();
+        var primarySlot = networkEvent.NetBufferIn.ReadBoolean();
+
+        var activateVBloodAbilityEvent = new ActivateVBloodAbilityEventArgs(
+            prefabGUID,
+            primarySlot
+        );
+
+        return activateVBloodAbilityEvent;
+    }
+}

--- a/Network/Events/Incoming/ActivateVBloodAbility/README
+++ b/Network/Events/Incoming/ActivateVBloodAbility/README
@@ -1,0 +1,1 @@
+This even triggers when a player moves an ability into their hotbar

--- a/Network/Events/Incoming/AdminAuth/AdminAuthEventArgs.cs
+++ b/Network/Events/Incoming/AdminAuth/AdminAuthEventArgs.cs
@@ -1,0 +1,8 @@
+namespace Wetstone.Network.Events;
+
+public class AdminAuthEventArgs : AbstractIncomingEventArgs
+{    
+    internal AdminAuthEventArgs()
+    {
+    }
+}

--- a/Network/Events/Incoming/AdminAuth/AdminAuthEventFactory.cs
+++ b/Network/Events/Incoming/AdminAuth/AdminAuthEventFactory.cs
@@ -1,0 +1,17 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.AdminAuth;
+
+internal class AdminAuthEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "AdminAuthEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var adminAuthEvent = new AdminAuthEventArgs();
+
+        return adminAuthEvent;
+    }
+}

--- a/Network/Events/Incoming/Ban/BanEventArgs.cs
+++ b/Network/Events/Incoming/Ban/BanEventArgs.cs
@@ -1,0 +1,11 @@
+﻿namespace Wetstone.Network.Events.Incoming.Ban;
+
+public class BanEventArgs : AbstractIncomingEventArgs
+{
+    public bool Unban { get; }
+
+    internal BanEventArgs(bool unban)
+    {
+        Unban = unban;
+    }
+}

--- a/Network/Events/Incoming/Ban/BanEventFactory.cs
+++ b/Network/Events/Incoming/Ban/BanEventFactory.cs
@@ -1,0 +1,19 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.Ban;
+
+internal class BanEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "BanEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var unban = (bool)networkEvent.NetBufferIn.ReadBoolean();
+
+        var ban = new BanEventArgs(unban);
+
+        return ban;
+    }
+}

--- a/Network/Events/Incoming/Ban/README
+++ b/Network/Events/Incoming/Ban/README
@@ -1,0 +1,1 @@
+This event is triggered when an admin calls the ban console command

--- a/Network/Events/Incoming/BecomeObserver/BecomeObserverEventArgs.cs
+++ b/Network/Events/Incoming/BecomeObserver/BecomeObserverEventArgs.cs
@@ -1,0 +1,11 @@
+namespace Wetstone.Network.Events;
+
+public class BecomeObserverEventArgs : AbstractIncomingEventArgs
+{    
+    public int Mode {get;}
+
+    internal BecomeObserverEventArgs(int mode)
+    {
+        Mode = mode;
+    }
+}

--- a/Network/Events/Incoming/BecomeObserver/BecomeObserverEventFactory.cs
+++ b/Network/Events/Incoming/BecomeObserver/BecomeObserverEventFactory.cs
@@ -1,0 +1,19 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.BecomeObserver;
+
+internal class BecomeObserverEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "BecomeObserverEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var mode = (int)networkEvent.NetBufferIn.ReadUInt32();
+
+        var becomeObserver = new BecomeObserverEventArgs(mode);
+
+        return becomeObserver;
+    }
+}

--- a/Network/Events/Incoming/BecomeObserver/README
+++ b/Network/Events/Incoming/BecomeObserver/README
@@ -1,0 +1,1 @@
+This event is triggered when an admin calls the toggleobserver console command

--- a/Network/Events/Incoming/BuildTileModel/BuildTileModelEventArgs.cs
+++ b/Network/Events/Incoming/BuildTileModel/BuildTileModelEventArgs.cs
@@ -1,0 +1,22 @@
+using ProjectM;
+using ProjectM.Network;
+using ProjectM.Tiles;
+using Unity.Mathematics;
+
+namespace Wetstone.Network.Events;
+
+public class BuildTileModelEventArgs : AbstractIncomingEventArgs
+{    
+    public PrefabGUID PrefabGuid { get; }
+    public float3 SpawnPosition { get; }
+    public TileRotation SpawnTileRotation { get; }
+    public NetworkId TransformedEntity { get; }
+
+    internal BuildTileModelEventArgs(PrefabGUID prefabGuid, float3 spawnPosition, TileRotation spawnTileRotation, NetworkId transformedEntity)
+    {
+        PrefabGuid = prefabGuid;
+        SpawnPosition = spawnPosition;
+        SpawnTileRotation = spawnTileRotation;
+        TransformedEntity = transformedEntity;
+    }
+}

--- a/Network/Events/Incoming/BuildTileModel/BuildTileModelEventFactory.cs
+++ b/Network/Events/Incoming/BuildTileModel/BuildTileModelEventFactory.cs
@@ -1,0 +1,35 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Tiles;
+using Unity.Mathematics;
+
+namespace Wetstone.Network.Events.Incoming.BuildTileModel;
+
+internal class BuildTileModelEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "BuildTileModelEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var netBufferIn = networkEvent.NetBufferIn;
+
+        var prefabGuid = netBufferIn.ReadPrefabGUID();
+        var x = netBufferIn.ReadFloat();
+        var y = netBufferIn.ReadFloat();
+        var z = netBufferIn.ReadFloat();
+
+        var rotation = (TileRotation)netBufferIn.ReadByte();
+
+        var networkId = netBufferIn.ReadNetworkId();
+
+        var buildTileModelEvent = new BuildTileModelEventArgs(
+            prefabGuid,
+            new float3(x, y, z),
+            rotation,
+            networkId
+        );
+
+        return buildTileModelEvent;
+    }
+}

--- a/Network/Events/Incoming/BuildTileModel/README
+++ b/Network/Events/Incoming/BuildTileModel/README
@@ -1,0 +1,1 @@
+This event is triggered when a player builds something from the build interface. Eg a border, or placing down a chest.

--- a/Network/Events/Incoming/CharacterRespawn/CharacterRespawnEventArgs.cs
+++ b/Network/Events/Incoming/CharacterRespawn/CharacterRespawnEventArgs.cs
@@ -1,0 +1,17 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class CharacterRespawnEventArgs : AbstractIncomingEventArgs
+{
+    public SpawnLocationType SpawnLocationType;
+    public uint SpawnOptionIndex;
+    public NetworkId SpawnLocationIcon;
+
+    internal CharacterRespawnEventArgs(SpawnLocationType spawnLocationType, uint spawnOptionIndex, NetworkId spawnLocationIcon)
+    {
+        SpawnLocationType = spawnLocationType;
+        SpawnOptionIndex = spawnOptionIndex;
+        SpawnLocationIcon = spawnLocationIcon;
+    }
+}

--- a/Network/Events/Incoming/CharacterRespawn/CharacterRespawnEventFactory.cs
+++ b/Network/Events/Incoming/CharacterRespawn/CharacterRespawnEventFactory.cs
@@ -1,0 +1,26 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events.Incoming.CharacterRespawn;
+
+internal class CharacterRespawnEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "CharacterRespawnEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var spawnLocationType = (SpawnLocationType)networkEvent.NetBufferIn.ReadByte();
+        var spawnOptionIndex = networkEvent.NetBufferIn.ReadUInt32();
+        var spawnLocationIcon = networkEvent.NetBufferIn.ReadNetworkId();
+
+        var eventArgs = new CharacterRespawnEventArgs(
+            spawnLocationType,
+            spawnOptionIndex,
+            spawnLocationIcon
+        );
+            
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/ChatMessage/ChatMessageEventArgs.cs
+++ b/Network/Events/Incoming/ChatMessage/ChatMessageEventArgs.cs
@@ -1,0 +1,18 @@
+using ProjectM.Network;
+using Unity.Collections;
+
+namespace Wetstone.Network.Events;
+
+public class ChatMessageEventArgs : AbstractIncomingEventArgs
+{    
+    public ChatMessageType MessageType { get; private set; }
+    public FixedString512 MessageText { get; private set; }
+    public NetworkId? ReceiverEntity { get; private set; }
+
+    internal ChatMessageEventArgs(ChatMessageType messageType, FixedString512 messageText, NetworkId? receiverEntity)
+    {
+        MessageType = messageType;
+        MessageText = messageText;
+        ReceiverEntity = receiverEntity;
+    }
+}

--- a/Network/Events/Incoming/ChatMessage/ChatMessageEventFactory.cs
+++ b/Network/Events/Incoming/ChatMessage/ChatMessageEventFactory.cs
@@ -1,0 +1,29 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events.Incoming.ChatMessage;
+
+internal class ChatMessageEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "ChatMessageEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var netBufferIn = networkEvent.NetBufferIn;
+
+        var messageType = (ChatMessageType)netBufferIn.ReadByte();
+        var messageText = netBufferIn.ReadFixedString512();
+        NetworkId? receiverEntity = null;
+        
+        if (messageType == ChatMessageType.Whisper)
+        {
+            receiverEntity = netBufferIn.ReadNetworkId();
+        }
+
+        var chatMessage = new ChatMessageEventArgs(messageType, messageText, receiverEntity);
+        
+        return chatMessage;
+    }
+}

--- a/Network/Events/Incoming/CreateClan_Request/CreateClan_RequestEventArgs.cs
+++ b/Network/Events/Incoming/CreateClan_Request/CreateClan_RequestEventArgs.cs
@@ -1,0 +1,13 @@
+namespace Wetstone.Network.Events;
+
+public class CreateClan_RequestEventArgs : AbstractIncomingEventArgs
+{    
+    public string ClanName { get; }
+    public string ClanMotto { get; }
+
+    internal CreateClan_RequestEventArgs(string clanName, string clanMotto)
+    {
+        ClanName = clanName;
+        ClanMotto = clanMotto;
+    }
+}

--- a/Network/Events/Incoming/CreateClan_Request/CreateClan_RequestEventFactory.cs
+++ b/Network/Events/Incoming/CreateClan_Request/CreateClan_RequestEventFactory.cs
@@ -1,0 +1,22 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.ChatMessage;
+
+internal class CreateClan_RequestEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "CreateClan_Request";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var netBufferIn = networkEvent.NetBufferIn;
+
+        var clanName = netBufferIn.ReadFixedString64();
+        var clanMotto = netBufferIn.ReadFixedString64();
+
+        var createClan_Request = new CreateClan_RequestEventArgs(clanName.ToString(), clanMotto.ToString());
+        
+        return createClan_Request;
+    }
+}

--- a/Network/Events/Incoming/CreateClan_Request/README
+++ b/Network/Events/Incoming/CreateClan_Request/README
@@ -1,0 +1,1 @@
+This event is triggered when a client requests to create a clan

--- a/Network/Events/Incoming/DeauthAdmin/DeauthAdminEventArgs.cs
+++ b/Network/Events/Incoming/DeauthAdmin/DeauthAdminEventArgs.cs
@@ -1,0 +1,8 @@
+namespace Wetstone.Network.Events;
+
+public class DeauthAdminEventArgs : AbstractIncomingEventArgs
+{    
+    internal DeauthAdminEventArgs()
+    {
+    }
+}

--- a/Network/Events/Incoming/DeauthAdmin/DeauthAdminEventFactory.cs
+++ b/Network/Events/Incoming/DeauthAdmin/DeauthAdminEventFactory.cs
@@ -1,0 +1,17 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.DeauthAdmin;
+
+internal class DeauthAdminEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "DeauthAdminEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var deauthEvent = new DeauthAdminEventArgs();
+
+        return deauthEvent;
+    }
+}

--- a/Network/Events/Incoming/DropInventoryItem/DropInventoryItemEventArgs.cs
+++ b/Network/Events/Incoming/DropInventoryItem/DropInventoryItemEventArgs.cs
@@ -1,0 +1,15 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class DropInventoryItemEventArgs : AbstractIncomingEventArgs
+{
+    public NetworkId Inventory { get; }
+    public uint Slot { get; }
+
+    internal DropInventoryItemEventArgs(NetworkId inventory, uint slot)
+    {
+        Inventory = inventory;
+        Slot = slot;
+    }
+}

--- a/Network/Events/Incoming/DropInventoryItem/DropInventoryItemEventFactory.cs
+++ b/Network/Events/Incoming/DropInventoryItem/DropInventoryItemEventFactory.cs
@@ -1,0 +1,20 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.BecomeObserver;
+
+internal class DropInventoryItemEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "DropInventoryItemEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var inventory = networkEvent.NetBufferIn.ReadNetworkId();
+        var slot = networkEvent.NetBufferIn.ReadUInt32();
+
+        var dropInventoryItem = new DropInventoryItemEventArgs(inventory, slot);
+
+        return dropInventoryItem;
+    }
+}

--- a/Network/Events/Incoming/DropInventoryItem/README
+++ b/Network/Events/Incoming/DropInventoryItem/README
@@ -1,0 +1,1 @@
+This event is triggered when a player drops an item from their inventory by dragging it out of the window

--- a/Network/Events/Incoming/DropItemAtSlot/DropItemAtSlotEventArgs.cs
+++ b/Network/Events/Incoming/DropItemAtSlot/DropItemAtSlotEventArgs.cs
@@ -1,0 +1,11 @@
+namespace Wetstone.Network.Events;
+
+public class DropItemAtSlotEventArgs : AbstractIncomingEventArgs
+{
+    public int Slot { get; }
+
+    internal DropItemAtSlotEventArgs(int slotIndex)
+    {
+        Slot = slotIndex;
+    }
+}

--- a/Network/Events/Incoming/DropItemAtSlot/DropItemAtSlotEventFactory.cs
+++ b/Network/Events/Incoming/DropItemAtSlot/DropItemAtSlotEventFactory.cs
@@ -1,0 +1,19 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.BecomeObserver;
+
+internal class DropItemAtSlotEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "DropItemAtSlotEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var slotIndex = networkEvent.NetBufferIn.ReadInt32();
+
+        var dropItemAtSlot = new DropItemAtSlotEventArgs(slotIndex);
+
+        return dropItemAtSlot;
+    }
+}

--- a/Network/Events/Incoming/DropItemAtSlot/README
+++ b/Network/Events/Incoming/DropItemAtSlot/README
@@ -1,0 +1,1 @@
+This even triggers when a player drops an item by pressing spacebar on the item in their inventory

--- a/Network/Events/Incoming/EnterShapeshift/EnterShapeshiftEventArgs.cs
+++ b/Network/Events/Incoming/EnterShapeshift/EnterShapeshiftEventArgs.cs
@@ -1,0 +1,15 @@
+using ProjectM;
+
+namespace Wetstone.Network.Events;
+
+public class EnterShapeshiftEventArgs : AbstractIncomingEventArgs
+{
+    public PrefabGUID Shapeshift;
+    public bool ExitOnSameForm;
+
+    internal EnterShapeshiftEventArgs(PrefabGUID shapeshift, bool exitOnSameForm)
+    {
+        Shapeshift = shapeshift;
+        ExitOnSameForm = exitOnSameForm;
+    }
+}

--- a/Network/Events/Incoming/EnterShapeshift/EnterShapeshiftEventFactory.cs
+++ b/Network/Events/Incoming/EnterShapeshift/EnterShapeshiftEventFactory.cs
@@ -1,0 +1,23 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.EnterShapeshift;
+
+internal class EnterShapeshiftEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "EnterShapeshiftEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var shapeshift = networkEvent.NetBufferIn.ReadPrefabGUID();
+        var exitOnSameForm = networkEvent.NetBufferIn.ReadBoolean();
+
+        var eventArgs = new EnterShapeshiftEventArgs(
+            shapeshift,
+            exitOnSameForm
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/EquipItem/EquipItemEventArgs.cs
+++ b/Network/Events/Incoming/EquipItem/EquipItemEventArgs.cs
@@ -1,0 +1,10 @@
+namespace Wetstone.Network.Events;
+
+public class EquipItemEventArgs : AbstractIncomingEventArgs
+{
+    public uint SlotIndex { get; }
+
+    internal EquipItemEventArgs(uint slotIndex) {
+        SlotIndex = slotIndex;
+    }
+}

--- a/Network/Events/Incoming/EquipItem/EquipItemEventFactory.cs
+++ b/Network/Events/Incoming/EquipItem/EquipItemEventFactory.cs
@@ -1,0 +1,21 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.EquipItem;
+
+internal class EquipItemEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "EquipItemEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var slotIndex = networkEvent.NetBufferIn.ReadUInt32();
+
+        var eventArgs = new EquipItemEventArgs(
+            slotIndex
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/GiveDebug/GiveDebugEventArgs.cs
+++ b/Network/Events/Incoming/GiveDebug/GiveDebugEventArgs.cs
@@ -1,0 +1,17 @@
+using ProjectM;
+
+namespace Wetstone.Network.Events;
+
+public class GiveDebugEventArgs : AbstractIncomingEventArgs
+{
+    public int Ammount { get; }
+
+    public int PrefabGuidHash { get; }
+
+    internal GiveDebugEventArgs(int ammount, int prefabguidhash) {
+        
+        Ammount = ammount;
+        PrefabGuidHash = prefabguidhash;    
+
+    }
+}

--- a/Network/Events/Incoming/GiveDebug/GiveDebugEventFactory.cs
+++ b/Network/Events/Incoming/GiveDebug/GiveDebugEventFactory.cs
@@ -1,0 +1,21 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Network;
+using ProjectM;
+
+namespace Wetstone.Network.Events.Incoming.GiveUpRevive;
+
+internal class GiveDebugEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "GiveDebugEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var prefabguidhash = (int)networkEvent.NetBufferIn.ReadUInt32();
+        var ammount = (int)networkEvent.NetBufferIn.ReadUInt32();
+        var eventArgs = new GiveDebugEventArgs(ammount, prefabguidhash);
+
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/GiveDebug/README
+++ b/Network/Events/Incoming/GiveDebug/README
@@ -1,0 +1,1 @@
+This event is triggered when a player admin use give console command

--- a/Network/Events/Incoming/GiveUpRevive/GiveUpReviveEventArgs.cs
+++ b/Network/Events/Incoming/GiveUpRevive/GiveUpReviveEventArgs.cs
@@ -1,0 +1,8 @@
+namespace Wetstone.Network.Events;
+
+public class GiveUpReviveEventArgs : AbstractIncomingEventArgs
+{
+    internal GiveUpReviveEventArgs() {
+        
+    }
+}

--- a/Network/Events/Incoming/GiveUpRevive/GiveUpReviveEventFactory.cs
+++ b/Network/Events/Incoming/GiveUpRevive/GiveUpReviveEventFactory.cs
@@ -1,0 +1,18 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events.Incoming.GiveUpRevive;
+
+internal class GiveUpReviveEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "GiveUpReviveEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var eventArgs = new GiveUpReviveEventArgs();
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/Kick/KickEventArgs.cs
+++ b/Network/Events/Incoming/Kick/KickEventArgs.cs
@@ -1,0 +1,11 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class KickEventArgs : AbstractIncomingEventArgs
+{
+
+    internal KickEventArgs()
+    {
+    }
+}

--- a/Network/Events/Incoming/Kick/KickEventFactory.cs
+++ b/Network/Events/Incoming/Kick/KickEventFactory.cs
@@ -1,0 +1,18 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events.Incoming.Kill;
+
+internal class KickEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "KickEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var kickEvent = new KickEventArgs();
+
+        return kickEvent;
+    }
+}

--- a/Network/Events/Incoming/Kick/README
+++ b/Network/Events/Incoming/Kick/README
@@ -1,0 +1,1 @@
+This event is triggered when an admin calls the kick console command

--- a/Network/Events/Incoming/Kill/KillEventArgs.cs
+++ b/Network/Events/Incoming/Kill/KillEventArgs.cs
@@ -1,0 +1,17 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class KillEventArgs : AbstractIncomingEventArgs
+{
+    public KillWho Who { get; }
+    public KillWhoFilter Filter { get; }
+    public NetworkId NetworkId { get; }
+
+    internal KillEventArgs(KillWho who, KillWhoFilter filter, NetworkId networkId)
+    {
+        Who = who;
+        Filter = filter;
+        NetworkId = networkId;
+    }
+}

--- a/Network/Events/Incoming/Kill/KillEventFactory.cs
+++ b/Network/Events/Incoming/Kill/KillEventFactory.cs
@@ -1,0 +1,26 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events.Incoming.Kill;
+
+internal class KillEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "KillEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var who = networkEvent.NetBufferIn.ReadByte();
+        var filter = networkEvent.NetBufferIn.ReadByte();
+        var networkId = networkEvent.NetBufferIn.ReadNetworkId();
+
+        var killEvent = new KillEventArgs(
+            (KillWho)who,
+            (KillWhoFilter)filter,
+            networkId
+        );
+
+        return killEvent;
+    }
+}

--- a/Network/Events/Incoming/MoveAllItemsBetweenInventories/MoveAllItemsBetweenInventoriesEventArgs.cs
+++ b/Network/Events/Incoming/MoveAllItemsBetweenInventories/MoveAllItemsBetweenInventoriesEventArgs.cs
@@ -1,0 +1,15 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class MoveAllItemsBetweenInventoriesEventArgs : AbstractIncomingEventArgs
+{
+    public NetworkId FromInventory { get; }
+    public NetworkId ToInventory { get; }
+
+    internal MoveAllItemsBetweenInventoriesEventArgs(NetworkId fromInventory, NetworkId toInventory)
+    {
+        FromInventory = fromInventory;
+        ToInventory = toInventory;
+    }
+}

--- a/Network/Events/Incoming/MoveAllItemsBetweenInventories/MoveAllItemsBetweenInventoriesEventFactory.cs
+++ b/Network/Events/Incoming/MoveAllItemsBetweenInventories/MoveAllItemsBetweenInventoriesEventFactory.cs
@@ -1,0 +1,25 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.MoveAllItemsBetweenInventories;
+
+internal class MoveAllItemsBetweenInventoriesEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "MoveAllItemsBetweenInventoriesEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var fromInventory = networkEvent.NetBufferIn.ReadNetworkId();
+        var toInventory = networkEvent.NetBufferIn.ReadNetworkId();
+
+        var eventArgs = new MoveAllItemsBetweenInventoriesEventArgs(
+            fromInventory,
+            toInventory
+        );
+
+        eventArgs.UserEntity = networkEvent.UserEntity;
+
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/MoveAllItemsBetweenInventories/README
+++ b/Network/Events/Incoming/MoveAllItemsBetweenInventories/README
@@ -1,0 +1,1 @@
+This event is triggered when "Take all" is pressed from a container

--- a/Network/Events/Incoming/MoveItemBetweenInventories/MoveItemBetweenInventoriesEventArgs.cs
+++ b/Network/Events/Incoming/MoveItemBetweenInventories/MoveItemBetweenInventoriesEventArgs.cs
@@ -1,0 +1,22 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class MoveItemBetweenInventoriesEventArgs : AbstractIncomingEventArgs
+{
+
+    public NetworkId FromInventory { get; }
+    public uint FromSlot { get; }
+    public NetworkId ToInventory { get; }
+    public uint ToSlot { get; }
+    public ItemTransferMethod TransferMethod { get; }
+
+    internal MoveItemBetweenInventoriesEventArgs(NetworkId fromInventory, uint fromSlot, NetworkId toInventory, uint toSlot, ItemTransferMethod transferMethod)
+    {
+        FromInventory = fromInventory;
+        FromSlot = fromSlot;
+        ToInventory = toInventory;
+        ToSlot = toSlot;
+        TransferMethod = transferMethod;
+    }
+}

--- a/Network/Events/Incoming/MoveItemBetweenInventories/MoveItemBetweenInventoriesEventFactory.cs
+++ b/Network/Events/Incoming/MoveItemBetweenInventories/MoveItemBetweenInventoriesEventFactory.cs
@@ -1,0 +1,33 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events.Incoming.MoveItemBetweenInventories;
+
+internal class MoveItemBetweenInventoriesEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "MoveItemBetweenInventoriesEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var fromInventory = networkEvent.NetBufferIn.ReadNetworkId();
+        var fromSlot = networkEvent.NetBufferIn.ReadUInt32();
+
+        // to inventory
+        var toInventory = networkEvent.NetBufferIn.ReadNetworkId();
+        var toSlot = networkEvent.NetBufferIn.ReadUInt32();
+
+        var transferMethod = (ItemTransferMethod)networkEvent.NetBufferIn.ReadByte();
+
+        var eventArgs = new MoveItemBetweenInventoriesEventArgs(
+            fromInventory,
+            fromSlot,
+            toInventory,
+            toSlot,
+            transferMethod
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/MoveItemBetweenInventories/README
+++ b/Network/Events/Incoming/MoveItemBetweenInventories/README
@@ -1,0 +1,1 @@
+This even triggers when an item is being moved inside inventories (either inventory to inventory, or inventory to container)

--- a/Network/Events/Incoming/MoveTileModel/MoveTileModelEventArgs.cs
+++ b/Network/Events/Incoming/MoveTileModel/MoveTileModelEventArgs.cs
@@ -1,0 +1,22 @@
+using ProjectM.Network;
+using ProjectM.Tiles;
+using Unity.Mathematics;
+
+namespace Wetstone.Network.Events;
+
+public class MoveTileModelEventArgs : AbstractIncomingEventArgs
+{
+
+    public NetworkId Tile {get;}
+
+    public float3 Position;
+
+    public TileRotation Rotation;
+
+    internal MoveTileModelEventArgs(NetworkId tile, float3 position, TileRotation rotation)
+    {
+        Tile = tile;
+        this.Position = position;
+        this.Rotation = rotation;
+    }
+}

--- a/Network/Events/Incoming/MoveTileModel/MoveTileModelEventFactory.cs
+++ b/Network/Events/Incoming/MoveTileModel/MoveTileModelEventFactory.cs
@@ -1,0 +1,30 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Tiles;
+using Unity.Mathematics;
+
+namespace Wetstone.Network.Events.Incoming.MoveTileModel;
+
+internal class MoveTileModelEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "MoveTileModelEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var networkId = networkEvent.NetBufferIn.ReadNetworkId();
+        var x = networkEvent.NetBufferIn.ReadFloat();
+        var y = networkEvent.NetBufferIn.ReadFloat();
+        var z = networkEvent.NetBufferIn.ReadFloat();
+
+        var rotation = (TileRotation)networkEvent.NetBufferIn.ReadByte();
+
+        var eventArgs = new MoveTileModelEventArgs(
+            networkId,
+            new float3(x, y, z),
+            rotation
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/MoveTileModel/README
+++ b/Network/Events/Incoming/MoveTileModel/README
@@ -1,0 +1,1 @@
+This event triggeres when an existing object has been moved via the build menu.

--- a/Network/Events/Incoming/PlayerTeleportDebug/PlayerTeleportDebugEventArgs.cs
+++ b/Network/Events/Incoming/PlayerTeleportDebug/PlayerTeleportDebugEventArgs.cs
@@ -1,0 +1,17 @@
+using Unity.Mathematics;
+using static ProjectM.Network.PlayerTeleportDebugEvent;
+
+namespace Wetstone.Network.Events;
+
+public class PlayerTeleportDebugEventArgs : AbstractIncomingEventArgs
+{
+    public float2 Position;
+    public TeleportTarget Target;
+
+    internal PlayerTeleportDebugEventArgs(float2 position, TeleportTarget target)
+    {
+        this.Position = position;
+        this.Target = target;
+    }
+    
+}

--- a/Network/Events/Incoming/PlayerTeleportDebug/PlayerTeleportDebugEventFactory.cs
+++ b/Network/Events/Incoming/PlayerTeleportDebug/PlayerTeleportDebugEventFactory.cs
@@ -1,0 +1,28 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using Unity.Mathematics;
+using static ProjectM.Network.PlayerTeleportDebugEvent;
+
+namespace Wetstone.Network.Events.Incoming.PlayerTeleportDebug;
+
+internal class PlayerTeleportDebugEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "PlayerTeleportDebugEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+
+        var x = networkEvent.NetBufferIn.ReadFloat();
+        var y = networkEvent.NetBufferIn.ReadFloat();
+
+        var target = (TeleportTarget)networkEvent.NetBufferIn.ReadUInt32();
+
+        var eventArgs = new PlayerTeleportDebugEventArgs(
+            new float2(x, y),
+            target
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/PlayerTeleportDebug/README
+++ b/Network/Events/Incoming/PlayerTeleportDebug/README
@@ -1,0 +1,1 @@
+This event is triggered when an admin teleports around using CTRL+SHIFT+Click on the map

--- a/Network/Events/Incoming/SetMapMarker/SetMapMarkerEventArgs.cs
+++ b/Network/Events/Incoming/SetMapMarker/SetMapMarkerEventArgs.cs
@@ -1,0 +1,13 @@
+using Unity.Mathematics;
+
+namespace Wetstone.Network.Events;
+
+public class SetMapMarkerEventArgs : AbstractIncomingEventArgs
+{    
+    public float2 Position { get; private set; }
+
+    internal SetMapMarkerEventArgs(float2 position)
+    {
+        Position = position;
+    }
+}

--- a/Network/Events/Incoming/SetMapMarker/SetMapMarkerEventFactory.cs
+++ b/Network/Events/Incoming/SetMapMarker/SetMapMarkerEventFactory.cs
@@ -1,0 +1,20 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.SetMapMarker;
+
+internal class SetMapMarkerEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "SetMapMarkerEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var x = networkEvent.NetBufferIn.ReadFloat();
+        var y = networkEvent.NetBufferIn.ReadFloat();
+
+        var mapMarker = new SetMapMarkerEventArgs(new Unity.Mathematics.float2(x, y));
+
+        return mapMarker;
+    }
+}

--- a/Network/Events/Incoming/ShareRefinement/ShareRefinementEventArgs.cs
+++ b/Network/Events/Incoming/ShareRefinement/ShareRefinementEventArgs.cs
@@ -1,0 +1,13 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class ShareRefinementEventArgs : AbstractIncomingEventArgs
+{
+    public NetworkId Station { get; }
+
+    internal ShareRefinementEventArgs(NetworkId station)
+    {
+        Station = station;
+    }
+}

--- a/Network/Events/Incoming/ShareRefinement/ShareRefinementEventFactory.cs
+++ b/Network/Events/Incoming/ShareRefinement/ShareRefinementEventFactory.cs
@@ -1,0 +1,21 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.ShareRefinement;
+
+internal class ShareRefinementEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "ShareRefinementEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var station = networkEvent.NetBufferIn.ReadNetworkId();
+
+        var eventArgs = new ShareRefinementEventArgs(
+            station
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/SmartMergeItemsBetweenInventories/SmartMergeItemsBetweenInventoriesEventArgs.cs
+++ b/Network/Events/Incoming/SmartMergeItemsBetweenInventories/SmartMergeItemsBetweenInventoriesEventArgs.cs
@@ -1,0 +1,16 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class SmartMergeItemsBetweenInventoriesEventArgs : AbstractIncomingEventArgs
+{
+
+    public NetworkId FromInventory;
+    public NetworkId ToInventory;
+    
+    internal SmartMergeItemsBetweenInventoriesEventArgs(NetworkId fromInventory, NetworkId toInventory)
+    {
+        FromInventory = fromInventory;
+        ToInventory = toInventory;
+    }
+}

--- a/Network/Events/Incoming/SmartMergeItemsBetweenInventories/SmartMergeItemsBetweenInventoriesEventFactory.cs
+++ b/Network/Events/Incoming/SmartMergeItemsBetweenInventories/SmartMergeItemsBetweenInventoriesEventFactory.cs
@@ -1,0 +1,23 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.SmartMergeItemsBetweenInventories;
+
+internal class SmartMergeItemsBetweenInventoriesEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "SmartMergeItemsBetweenInventoriesEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var from = networkEvent.NetBufferIn.ReadNetworkId();
+        var to = networkEvent.NetBufferIn.ReadNetworkId();
+
+        var eventArgs = new SmartMergeItemsBetweenInventoriesEventArgs(
+            from,
+            to
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/SortAllItems/README
+++ b/Network/Events/Incoming/SortAllItems/README
@@ -1,0 +1,1 @@
+This event is triggered when a player clicks the `Sort` button either in their own inventory or in a container.

--- a/Network/Events/Incoming/SortAllItems/SortAllItemsEventArgs.cs
+++ b/Network/Events/Incoming/SortAllItems/SortAllItemsEventArgs.cs
@@ -1,0 +1,14 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class SortAllItemsEventArgs : AbstractIncomingEventArgs
+{
+
+    public NetworkId Inventory {get;}
+
+    internal SortAllItemsEventArgs(NetworkId inventory) {
+        this.Inventory = inventory;
+    }
+    
+}

--- a/Network/Events/Incoming/SortAllItems/SortAllItemsEventFactory.cs
+++ b/Network/Events/Incoming/SortAllItems/SortAllItemsEventFactory.cs
@@ -1,0 +1,19 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.SortAllItems;
+
+internal class SortAllItemsEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "SortAllItemsEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var inventory = networkEvent.NetBufferIn.ReadNetworkId();
+
+        var eventArgs = new SortAllItemsEventArgs(inventory);
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/StartCraftItem/StartCraftItemEventArgs.cs
+++ b/Network/Events/Incoming/StartCraftItem/StartCraftItemEventArgs.cs
@@ -1,0 +1,17 @@
+using ProjectM;
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class StartCraftItemEventArgs : AbstractIncomingEventArgs
+{
+    public NetworkId Workstation;
+    public PrefabGUID RecipeId;
+        
+    internal StartCraftItemEventArgs(NetworkId workstation, PrefabGUID recipeId)
+    {
+        Workstation = workstation;
+        RecipeId = recipeId;
+    }
+
+}

--- a/Network/Events/Incoming/StartCraftItem/StartCraftItemEventFactory.cs
+++ b/Network/Events/Incoming/StartCraftItem/StartCraftItemEventFactory.cs
@@ -1,0 +1,24 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events.Incoming.StartCraftItem;
+
+internal class StartCraftItemEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "StartCraftItemEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var workstation = networkEvent.NetBufferIn.ReadNetworkId();
+        var recipeId = networkEvent.NetBufferIn.ReadPrefabGUID();
+        
+        var eventArgs = new StartCraftItemEventArgs(
+            workstation,
+            recipeId
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/StartEditTileModel/README
+++ b/Network/Events/Incoming/StartEditTileModel/README
@@ -1,0 +1,1 @@
+In build mode, when you select (click on) a object to move, this event is triggered.

--- a/Network/Events/Incoming/StartEditTileModel/StartEditTileModelEventArgs.cs
+++ b/Network/Events/Incoming/StartEditTileModel/StartEditTileModelEventArgs.cs
@@ -1,0 +1,13 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class StartEditTileModelEventArgs : AbstractIncomingEventArgs
+{
+    public NetworkId Tile { get; }
+
+    internal StartEditTileModelEventArgs(NetworkId tile)
+    {
+        Tile = tile;
+    }
+}

--- a/Network/Events/Incoming/StartEditTileModel/StartEditTileModelEventFactory.cs
+++ b/Network/Events/Incoming/StartEditTileModel/StartEditTileModelEventFactory.cs
@@ -1,0 +1,19 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.StartEditTileModel;
+
+internal class StartEditTileModelEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "StartEditTileModelEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var tile = networkEvent.NetBufferIn.ReadNetworkId();
+
+        var eventArgs = new StartEditTileModelEventArgs(tile);
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/StopInteractingWithObject/README
+++ b/Network/Events/Incoming/StopInteractingWithObject/README
@@ -1,0 +1,1 @@
+This event is triggered when a player closes a container / workbench.

--- a/Network/Events/Incoming/StopInteractingWithObject/StopInteractingWithObjectEventArgs.cs
+++ b/Network/Events/Incoming/StopInteractingWithObject/StopInteractingWithObjectEventArgs.cs
@@ -1,0 +1,13 @@
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class StopInteractingWithObjectEventArgs : AbstractIncomingEventArgs
+{
+    public NetworkId Target { get; }
+
+    internal StopInteractingWithObjectEventArgs(NetworkId target)
+    {
+        Target = target;
+    }
+}

--- a/Network/Events/Incoming/StopInteractingWithObject/StopInteractingWithObjectEventFactory.cs
+++ b/Network/Events/Incoming/StopInteractingWithObject/StopInteractingWithObjectEventFactory.cs
@@ -1,0 +1,21 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.StopInteractingWithObject;
+
+internal class StopInteractingWithObjectEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "StopInteractingWithObjectEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var target = networkEvent.NetBufferIn.ReadNetworkId();
+
+        var eventArgs = new StopInteractingWithObjectEventArgs(
+            target
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/UnequipItem/UnequipItemEventArgs.cs
+++ b/Network/Events/Incoming/UnequipItem/UnequipItemEventArgs.cs
@@ -1,0 +1,18 @@
+using ProjectM;
+using ProjectM.Network;
+
+namespace Wetstone.Network.Events;
+
+public class UnequipItemEventArgs : AbstractIncomingEventArgs
+{
+    public EquipmentType EquipmentType;
+    public NetworkId ToInventory;
+    public uint ToSlotIndex;
+
+    internal UnequipItemEventArgs(EquipmentType equipmentType, NetworkId toInventory, uint toSlotIndex)
+    {
+        EquipmentType = equipmentType;
+        ToInventory = toInventory;
+        ToSlotIndex = toSlotIndex;
+    }
+}

--- a/Network/Events/Incoming/UnequipItem/UnequipItemEventFactory.cs
+++ b/Network/Events/Incoming/UnequipItem/UnequipItemEventFactory.cs
@@ -1,0 +1,26 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM;
+
+namespace Wetstone.Network.Events.Incoming.UnequipItem;
+
+internal class UnequipItemEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "UnequipItemEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var equipmentType = (EquipmentType)networkEvent.NetBufferIn.ReadByte();
+        var toInventory = networkEvent.NetBufferIn.ReadNetworkId();
+        var toSlotIndex = networkEvent.NetBufferIn.ReadUInt32();
+
+        var eventArgs = new UnequipItemEventArgs(
+            equipmentType,
+            toInventory,
+            toSlotIndex
+        );
+
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/UseDefaultAction/UseDefaultActionEventArgs.cs
+++ b/Network/Events/Incoming/UseDefaultAction/UseDefaultActionEventArgs.cs
@@ -1,0 +1,15 @@
+using ProjectM;
+
+namespace Wetstone.Network.Events;
+
+public class UseDefaultActionEventArgs : AbstractIncomingEventArgs
+{
+    public PrefabGUID Action;
+    public bool ExitOnSameForm;
+
+    internal UseDefaultActionEventArgs(PrefabGUID action, bool exitOnSameForm)
+    {
+        Action = action;
+        ExitOnSameForm = exitOnSameForm;
+    }
+}

--- a/Network/Events/Incoming/UseDefaultAction/UseDefaultActionEventFactory.cs
+++ b/Network/Events/Incoming/UseDefaultAction/UseDefaultActionEventFactory.cs
@@ -1,0 +1,24 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Events.Incoming.UseDefaultAction;
+
+internal class UseDefaultActionEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "UseDefaultActionEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+
+        var action = networkEvent.NetBufferIn.ReadPrefabGUID();
+        var exitOnSameForm = networkEvent.NetBufferIn.ReadBoolean();
+
+        var eventArgs = new UseDefaultActionEventArgs(
+            action,
+            exitOnSameForm
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Incoming/VivoxClient/README
+++ b/Network/Events/Incoming/VivoxClient/README
@@ -1,0 +1,2 @@
+This event is triggered by the VOIP service of the client to request a connection to the voip services, i think.
+I am personally unable to verify this.

--- a/Network/Events/Incoming/VivoxClient/VivoxClientEventArgs.cs
+++ b/Network/Events/Incoming/VivoxClient/VivoxClientEventArgs.cs
@@ -1,0 +1,13 @@
+using ProjectM;
+
+namespace Wetstone.Network.Events;
+
+public class VivoxClientEventArgs : AbstractIncomingEventArgs
+{
+    public VivoxRequestType RequestType { get; }
+
+    internal VivoxClientEventArgs(VivoxRequestType requestType)
+    {
+        RequestType = requestType;
+    }
+}

--- a/Network/Events/Incoming/VivoxClient/VivoxClientEventFactory.cs
+++ b/Network/Events/Incoming/VivoxClient/VivoxClientEventFactory.cs
@@ -1,0 +1,22 @@
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using ProjectM;
+
+namespace Wetstone.Network.Events.Incoming.VivoxClient;
+
+internal class VivoxClientEventFactory : IIncomingNetworkEventFactory
+{
+    public string EventName => "VivoxClientEvent";
+    public bool Enabled => true;
+
+    public AbstractEventArgs Build(IncomingNetworkEvent networkEvent)
+    {
+        var requestType = (VivoxRequestType)networkEvent.NetBufferIn.ReadByte();
+
+        var eventArgs = new VivoxClientEventArgs(
+            requestType
+        );
+        
+        return eventArgs;
+    }
+}

--- a/Network/Events/Outgoing/ChatMessageServer/README
+++ b/Network/Events/Outgoing/ChatMessageServer/README
@@ -1,0 +1,2 @@
+This event is a response from a ChatMessage event from the client.
+I'm guessing this one is responsible for propogating the messages to all other clients.

--- a/Network/Events/Outgoing/ClaimedAchievements/README
+++ b/Network/Events/Outgoing/ClaimedAchievements/README
@@ -1,0 +1,2 @@
+Speculation:
+This event triggers on player join when the server is sent their achivements progression.

--- a/Network/Events/Outgoing/ClientActionResponse/README
+++ b/Network/Events/Outgoing/ClientActionResponse/README
@@ -1,0 +1,6 @@
+This is a server response to a bunch of client request events:
+
+- MoveItemBetweenInventoriesEvent
+- SortAllItemsEvent
+
+Probably more

--- a/Network/Events/Outgoing/CreateClan_Response/README
+++ b/Network/Events/Outgoing/CreateClan_Response/README
@@ -1,0 +1,1 @@
+This event is triggered when a server acknowlages the creation of a clan

--- a/Network/Events/Outgoing/DiscoveredMapZones/README
+++ b/Network/Events/Outgoing/DiscoveredMapZones/README
@@ -1,0 +1,2 @@
+Speculation:
+This event is triggered when a player joins the server and is sent all their previously discovered map zones

--- a/Network/Events/Outgoing/InitialUnlockedProgression/README
+++ b/Network/Events/Outgoing/InitialUnlockedProgression/README
@@ -1,0 +1,2 @@
+Speculation:
+This event triggers when a player joins the server and has their quest progression sent.

--- a/Network/Events/Outgoing/MapZoneDiscovered/README
+++ b/Network/Events/Outgoing/MapZoneDiscovered/README
@@ -1,0 +1,1 @@
+This event is triggered when a player discovers a new zone on the map.

--- a/Network/Events/Outgoing/RevealedMap/README
+++ b/Network/Events/Outgoing/RevealedMap/README
@@ -1,0 +1,2 @@
+Speculation:
+This event triggers when a player joins the server and has their revealed map data sent.

--- a/Network/Events/Outgoing/UserDownedServer/UserDownedServerEventArgs.cs
+++ b/Network/Events/Outgoing/UserDownedServer/UserDownedServerEventArgs.cs
@@ -1,0 +1,15 @@
+using Unity.Entities;
+
+namespace Wetstone.Network.Events;
+
+public class UserDownedServerEventArgs : AbstractEventArgs
+{
+    public Entity Target;
+    public Entity Source;
+
+    internal UserDownedServerEventArgs(Entity Target, Entity Source)
+    {
+        this.Target = Target;
+        this.Source = Source;
+    }
+}

--- a/Network/Events/Outgoing/UserDownedServer/UserDownedServerEventFactory.cs
+++ b/Network/Events/Outgoing/UserDownedServer/UserDownedServerEventFactory.cs
@@ -1,0 +1,47 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using Wetstone.Util;
+using ProjectM.Network;
+using Wetstone.API;
+
+namespace Wetstone.Network.Events.Outgoing.UserDownedServer
+{
+    internal class UserDownedServerEventFactory : IOutgoingNetworkEventFactory
+    {
+        public string EventName => "UserDownedServerEvent";
+        public bool Enabled => true;
+        
+        public AbstractEventArgs Build(OutgoingNetworkEvent networkEvent)
+        {
+            var networkIdSystem = VWorld.Server.GetExistingSystem<NetworkIdSystem>();
+
+            var userDownedServerEventData = networkEvent.EntityManager.GetComponentData<UserDownedServerEvent>(networkEvent.Entity);
+
+            var targetEntity = networkIdSystem._NetworkIdToEntityMap[userDownedServerEventData.Target];
+            var sourceEntity = networkIdSystem._NetworkIdToEntityMap[userDownedServerEventData.Source];
+
+
+            // This is an interesting one.
+            // Target is always a player, which is obvious.
+            // Source can have PlayerCharacter, if it does not, it's most likely an NPC, not sure which component to check for.
+            // Source can also be equal to Target, when the player dies from the sun, eg, suicide.
+            // Which is a literal `if (e.Target == e.Source)` check.
+
+            // My goal (for this project) is to make these events as user-friendly as possible,
+            // where the user (developer) doesn't need to do a bazillion GetComponentData's to get the information available on the entities
+            // If we can automate that somehow, by adding all the useful bits of information to the EventArgs (not just for this one)
+            // That'd be amazing.
+
+
+            // var targetPlayerCharacter = networkEvent.EntityManager.GetComponentData<PlayerCharacter>(targetEntity);
+            // var sourcePlayerCharacter = networkEvent.EntityManager.GetComponentData<PlayerCharacter>(sourceEntity);
+
+            var userDownedServer = new UserDownedServerEventArgs(
+                targetEntity,
+                sourceEntity
+            );
+
+            return userDownedServer;
+        }
+    }
+}

--- a/Network/Events/Outgoing/UserKillServer/UserKillServerEventArgs.cs
+++ b/Network/Events/Outgoing/UserKillServer/UserKillServerEventArgs.cs
@@ -1,0 +1,15 @@
+using Unity.Entities;
+
+namespace Wetstone.Network.Events;
+
+public class UserKillServerEventArgs : AbstractEventArgs
+{
+    public Entity Killer;
+    public Entity Died;
+
+    internal UserKillServerEventArgs(Entity Killer, Entity Died)
+    {
+        this.Killer = Killer;
+        this.Died = Died;
+    }
+}

--- a/Network/Events/Outgoing/UserKillServer/UserKillServerEventFactory.cs
+++ b/Network/Events/Outgoing/UserKillServer/UserKillServerEventFactory.cs
@@ -1,0 +1,30 @@
+﻿using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+using Wetstone.Util;
+using ProjectM.Network;
+using Wetstone.API;
+
+namespace Wetstone.Network.Events.Outgoing.UserKillServer;
+
+internal class UserKillServerEventFactory : IOutgoingNetworkEventFactory
+{
+    public string EventName => "UserKillServerEvent";
+    public bool Enabled => true;
+    
+    public AbstractEventArgs Build(OutgoingNetworkEvent networkEvent)
+    {
+        var networkIdSystem = VWorld.Server.GetExistingSystem<NetworkIdSystem>();
+
+        var userDownedServerEventData = networkEvent.EntityManager.GetComponentData<UserKillServerEvent>(networkEvent.Entity);
+
+        var diedEntity = networkIdSystem._NetworkIdToEntityMap[userDownedServerEventData.Died];
+        var killerEntity = networkIdSystem._NetworkIdToEntityMap[userDownedServerEventData.Killer];
+
+        var userKillServer = new UserKillServerEventArgs(
+            killerEntity,
+            diedEntity
+        );
+        
+        return userKillServer;
+    }
+}

--- a/Network/Events/Outgoing/VivoxServerReject/README
+++ b/Network/Events/Outgoing/VivoxServerReject/README
@@ -1,0 +1,1 @@
+This event is sent back from the server if Vivox, the voip service, is not configured / running.

--- a/Network/Extensions/NetBufferInExtensions.cs
+++ b/Network/Extensions/NetBufferInExtensions.cs
@@ -1,0 +1,24 @@
+using ProjectM;
+using ProjectM.Network;
+using Stunlock.Network;
+
+// namespace intentionally omitted
+
+internal static class NetBufferInExtensions
+{
+    internal static NetworkId ReadNetworkId(this NetBufferIn self)
+    {
+        var index = self.ReadRangedInteger(0, 0xffffe);
+        var generation = self.ReadByte();
+
+        return new NetworkId() {
+            Index = index,
+            Generation = generation
+        };
+    }
+
+    internal static PrefabGUID ReadPrefabGUID(this NetBufferIn self)
+    {
+        return new PrefabGUID((int)self.ReadUInt32());
+    }
+}

--- a/Network/Interfaces/IIncomingNetworkEventFactory.cs
+++ b/Network/Interfaces/IIncomingNetworkEventFactory.cs
@@ -1,0 +1,9 @@
+﻿using Wetstone.Network.Events;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Interfaces;
+
+public interface IIncomingNetworkEventFactory : INetworkEventFactory
+{
+    AbstractEventArgs Build(IncomingNetworkEvent networkFactory);
+}

--- a/Network/Interfaces/INetworkEventFactory.cs
+++ b/Network/Interfaces/INetworkEventFactory.cs
@@ -1,0 +1,7 @@
+﻿namespace Wetstone.Network.Interfaces;
+
+public interface INetworkEventFactory
+{
+    string EventName { get; }
+    bool Enabled { get; }
+}

--- a/Network/Interfaces/IOutgoingNetworkEventFactory.cs
+++ b/Network/Interfaces/IOutgoingNetworkEventFactory.cs
@@ -1,0 +1,9 @@
+﻿using Wetstone.Network.Events;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network.Interfaces;
+
+public interface IOutgoingNetworkEventFactory : INetworkEventFactory
+{
+    AbstractEventArgs Build(OutgoingNetworkEvent networkFactory);
+}

--- a/Network/Logger/Handler/ConsoleLogHandler.cs
+++ b/Network/Logger/Handler/ConsoleLogHandler.cs
@@ -1,0 +1,18 @@
+using System.Threading.Tasks;
+using BepInEx.Logging;
+
+namespace Wetstone.Network.Logger.Handler;
+
+class ConsoleLogHandler : ILogHandler
+{
+    public bool Accept(LogLevel level)
+    {
+        return level <= LogLevel.Info;
+    }
+
+    public Task Handle(LogLevel level, string message)
+    {
+        WetstonePlugin.Instance?.Log.Log(level, message);
+        return Task.CompletedTask;
+    }
+}

--- a/Network/Logger/Handler/FileLogHandler.cs
+++ b/Network/Logger/Handler/FileLogHandler.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using BepInEx.Logging;
+
+namespace Wetstone.Network.Logger.Handler;
+
+class FileLogHandler : ILogHandler
+{
+    private static readonly string LogFilePath = $"logs/{PluginInfo.PLUGIN_GUID}.log";
+
+    public FileLogHandler()
+    {
+        System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(LogFilePath));
+    }
+
+    public bool Accept(LogLevel level)
+    {
+        return level <= LogLevel.All;
+    }
+
+    public Task Handle(LogLevel level, string message)
+    {
+        using (FileStream fs = new FileStream(LogFilePath, FileMode.Append, FileAccess.Write, FileShare.None))
+        {
+            fs.Write(System.Text.Encoding.UTF8.GetBytes(this.FormatLog(level, message)));
+        }
+        return Task.CompletedTask;
+    }
+
+    private string FormatLog(LogLevel level, string message)
+    {
+        var timestamp = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+        return $"[{timestamp}] [{level}] {message}\r\n";
+    }
+}

--- a/Network/Logger/Handler/ILogHandler.cs
+++ b/Network/Logger/Handler/ILogHandler.cs
@@ -1,0 +1,11 @@
+using System.Threading.Tasks;
+using BepInEx.Logging;
+
+namespace Wetstone.Network.Logger.Handler;
+
+interface ILogHandler
+{
+    bool Accept(LogLevel level);
+
+    Task Handle(LogLevel level, string message);
+}

--- a/Network/Logger/Logger.cs
+++ b/Network/Logger/Logger.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using BepInEx.Logging;
+using Wetstone.Network.Logger.Handler;
+
+namespace Wetstone.Network.Logger;
+
+internal class Logger
+{
+    public List<ILogHandler> Handlers { get; } = new List<ILogHandler>();
+
+    public void RegisterLogHandler(ILogHandler handler)
+    {
+        Handlers.Add(handler);
+    }
+
+    public async Task LogFatal(string message)
+    {
+        await Log(LogLevel.Fatal, message);
+    }
+
+    public async Task LogError(string message)
+    {
+        await Log(LogLevel.Error, message);
+    }
+
+    public async Task LogWarning(string message)
+    {
+        await Log(LogLevel.Warning, message);
+    }
+
+    public async Task LogMessage(string message)
+    {
+        await Log(LogLevel.Message, message);
+    }
+
+    public async Task LogInfo(string message)
+    {
+        await Log(LogLevel.Info, message);
+    }
+
+    public async Task LogDebug(string message)
+    {
+        await Log(LogLevel.Debug, message);
+    }
+
+    public async Task Log(LogLevel level, string message)
+    {
+        foreach (var handler in Handlers)
+        {
+            if (handler.Accept(level)) {
+                await handler.Handle(level, message);
+            }
+        }
+    }
+}

--- a/Network/Models/IncomingNetworkEvent.cs
+++ b/Network/Models/IncomingNetworkEvent.cs
@@ -1,0 +1,30 @@
+﻿using ProjectM;
+using Stunlock.Network;
+using Unity.Entities;
+using Wetstone.API;
+
+namespace Wetstone.Network.Models;
+
+public class IncomingNetworkEvent
+{
+    public NetBufferIn NetBufferIn { get; }
+    public int EventId { get; }
+    public NetworkEvents_Serialize.DeserializeNetworkEventParams EventParams { get; }
+    public int FromUserIndex { get; }
+    public ServerBootstrapSystem.ServerClient ServerClient { get; }
+    public Entity UserEntity { get; }
+
+    internal IncomingNetworkEvent(NetBufferIn netBufferIn, int eventId, NetworkEvents_Serialize.DeserializeNetworkEventParams eventParams)
+    {
+        NetBufferIn = netBufferIn;
+        EventId = eventId;
+        EventParams = eventParams;
+        FromUserIndex = eventParams.FromUserIndex;
+
+        var serverBootstrap = VWorld.Server.GetExistingSystem<ServerBootstrapSystem>()!;
+        ServerClient = serverBootstrap._ApprovedUsersLookup[FromUserIndex];
+
+        UserEntity = ServerClient.UserEntity;
+    }
+
+}

--- a/Network/Models/OutgoingNetworkEvent.cs
+++ b/Network/Models/OutgoingNetworkEvent.cs
@@ -1,0 +1,20 @@
+﻿using ProjectM.Network;
+using Unity.Entities;
+
+namespace Wetstone.Network.Models;
+
+public class OutgoingNetworkEvent
+{
+    internal OutgoingNetworkEvent(NetworkEventType networkEventType, int eventId, EntityManager entityManager, Entity entity)
+    {
+        NetworkEventType = networkEventType;
+        EventId = eventId;
+        EntityManager = entityManager;
+        Entity = entity;
+    }
+
+    public NetworkEventType NetworkEventType { get; }
+    public int EventId { get; }
+    public EntityManager EntityManager { get; }
+    public Entity Entity { get; }
+}

--- a/Network/NetworkEventManager.cs
+++ b/Network/NetworkEventManager.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Wetstone.Network.Events;
+using Wetstone.Network.Interfaces;
+using Wetstone.Network.Models;
+
+namespace Wetstone.Network;
+
+internal static class NetworkEventManager
+{
+    private static readonly Dictionary<string, IIncomingNetworkEventFactory> IncomingEventHandlers = new();
+    private static readonly Dictionary<string, IOutgoingNetworkEventFactory> OutgoingEventHandlers = new();
+
+    internal static bool HandleEvent(IncomingNetworkEvent networkEvent, out bool cancelled)
+    {
+        cancelled = false;
+        var eventName = NetworkEvents.GetNetworkEventName(networkEvent.EventId);
+
+        
+
+        if (IncomingEventHandlers.TryGetValue(eventName, out var eventFactory) && eventFactory.Enabled)
+        {
+            var args = eventFactory.Build(networkEvent);
+            if (args is AbstractIncomingEventArgs incomingArgs)
+            {
+                incomingArgs.UserEntity = networkEvent.UserEntity;
+            }
+
+            ServerEvent.InvokeEvent(args);
+            return true;
+        }
+
+        return false;
+    }
+
+    internal static bool HandleEvent(OutgoingNetworkEvent networkEvent, out bool cancelled)
+    {
+        cancelled = false;
+        var eventName = NetworkEvents.GetNetworkEventName(networkEvent.EventId);
+        if (OutgoingEventHandlers.TryGetValue(eventName, out var eventHandler) && eventHandler.Enabled)
+        {
+            var args = eventHandler.Build(networkEvent);
+            ServerEvent.InvokeEvent(args);
+            return true;
+        }
+
+        return false;
+    }
+
+    internal static void RegisterEvents(Type? type = null)
+    {
+        type ??= typeof(NetworkEventManager);
+        var assembly = Assembly.GetAssembly(type);
+
+        var incomingType = typeof(IIncomingNetworkEventFactory);
+        var incomingTypes = assembly.GetTypes().Where(t => incomingType.IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract);
+        foreach (var incomingEventType in incomingTypes)
+        {
+            var instance = (IIncomingNetworkEventFactory)Activator.CreateInstance(incomingEventType);
+            IncomingEventHandlers[instance.EventName] = instance;
+        }
+
+        var outgoingType = typeof(IOutgoingNetworkEventFactory);
+        var outgoingTypes = assembly.GetTypes().Where(t => outgoingType.IsAssignableFrom(t) && !t.IsInterface && !t.IsAbstract);
+        foreach (var outgoingEventType in outgoingTypes)
+        {
+            var instance = (IOutgoingNetworkEventFactory)Activator.CreateInstance(outgoingEventType);
+            OutgoingEventHandlers[instance.EventName] = instance;
+        }
+
+    }
+}

--- a/Network/ServerEvent.cs
+++ b/Network/ServerEvent.cs
@@ -1,5 +1,6 @@
 using System;
 using Wetstone.Network.Events;
+using Wetstone.Network.Events.Incoming.Ban;
 
 namespace Wetstone.Network;
 
@@ -21,6 +22,11 @@ public static class ServerEvent
     /// A player logs in as an admin.
     /// </summary>
     public static event GenericEventDelegate<AdminAuthEventArgs>? AdminAuth;
+
+    /// <summary>
+    /// A player admin ban another player
+    /// </summary>
+    public static event GenericEventDelegate<BanEventArgs>? Ban;
 
     /// <summary>
     /// A player logs out as an admin.
@@ -147,6 +153,11 @@ public static class ServerEvent
     public static event GenericEventDelegate<EnterShapeshiftEventArgs>? EnterShapeshift;
 
     /// <summary>
+    /// A player admin use give or giveset console command
+    /// </summary>
+    public static event GenericEventDelegate<GiveDebugEventArgs>? GiveDebug;
+
+    /// <summary>
     /// A player gives up after being downed.
     /// For some reason this event triggers multiple times if the player holds X for longer.
     /// </summary>
@@ -175,11 +186,13 @@ public static class ServerEvent
             nameof(KillEventArgs) => KillEvent,
             nameof(KickEventArgs) => KickEvent,
             nameof(AdminAuthEventArgs) => AdminAuth,
+            nameof(BanEventArgs) => Ban,
             nameof(EquipItemEventArgs) => EquipItem,
             nameof(ChatMessageEventArgs) => ChatMessage,
             nameof(DeauthAdminEventArgs) => DeauthAdmin,
             nameof(UnequipItemEventArgs) => UnequipItem,
             nameof(VivoxClientEventArgs) => VivoxClient,
+            nameof(GiveDebugEventArgs) => GiveDebug,
             nameof(GiveUpReviveEventArgs) => GiveUpRevive,
             nameof(SetMapMarkerEventArgs) => SetMapMarker,
             nameof(SortAllItemsEventArgs) => SortAllItems,

--- a/Network/ServerEvent.cs
+++ b/Network/ServerEvent.cs
@@ -72,6 +72,11 @@ public static class ServerEvent
     public static event GenericEventDelegate<DropItemAtSlotEventArgs>? DropItemAtSlot;
 
     /// <summary>
+    /// A player admin kick another player
+    /// </summary>
+    public static event GenericEventDelegate<KickEventArgs>? KickEvent;
+
+    /// <summary>
     /// A player dies (afaik only when a player uses "Unstuck" from the menu)
     /// </summary>
     public static event GenericEventDelegate<KillEventArgs>? KillEvent;
@@ -168,6 +173,7 @@ public static class ServerEvent
         return e.GetType().Name switch
         {
             nameof(KillEventArgs) => KillEvent,
+            nameof(KickEventArgs) => KickEvent,
             nameof(AdminAuthEventArgs) => AdminAuth,
             nameof(EquipItemEventArgs) => EquipItem,
             nameof(ChatMessageEventArgs) => ChatMessage,

--- a/Network/ServerEvent.cs
+++ b/Network/ServerEvent.cs
@@ -1,0 +1,217 @@
+using System;
+using Wetstone.Network.Events;
+
+namespace Wetstone.Network;
+
+public static class ServerEvent
+{
+    static ServerEvent()
+    {
+        NetworkEventManager.RegisterEvents(typeof(ServerEvent));
+    }
+
+    public delegate void GenericEventDelegate<T>(T args) where T : AbstractEventArgs;
+
+    /// <summary>
+    /// A player sends a chat message.
+    /// </summary>
+    public static event GenericEventDelegate<ChatMessageEventArgs>? ChatMessage;
+
+    /// <summary>
+    /// A player logs in as an admin.
+    /// </summary>
+    public static event GenericEventDelegate<AdminAuthEventArgs>? AdminAuth;
+
+    /// <summary>
+    /// A player logs out as an admin.
+    /// </summary>
+    public static event GenericEventDelegate<DeauthAdminEventArgs>? DeauthAdmin;
+
+    /// <summary>
+    /// A player sets a waypoint on their map.
+    /// </summary>
+    public static event GenericEventDelegate<SetMapMarkerEventArgs>? SetMapMarker;
+
+    /// <summary>
+    /// A player has been downed by another player in PvP.
+    public static event GenericEventDelegate<UserDownedServerEventArgs>? UserDownedServer;
+
+    /// <summary>
+    /// A player adds an ability to their hotbar.
+    /// </summary>
+    public static event GenericEventDelegate<ActivateVBloodAbilityEventArgs>? ActivateVBloodAbility;
+
+    /// <summary>
+    /// A player creates a clan.
+    /// </summary>
+    public static event GenericEventDelegate<CreateClan_RequestEventArgs>? CreateClan_Request;
+
+    /// <summary>
+    /// A player builds a tile model.
+    /// </summary>
+    public static event GenericEventDelegate<BuildTileModelEventArgs>? BuildTileModel;
+
+    /// <summary>
+    /// A player kills something, including resource nodes and foliage.
+    /// </summary>
+    public static event GenericEventDelegate<UserKillServerEventArgs>? UserKillServer;
+
+    /// <summary>
+    /// An admin changes their observer state.
+    /// </summary>
+    public static event GenericEventDelegate<BecomeObserverEventArgs>? BecomeObserver;
+
+    /// <summary>
+    /// A player drops an item from their inventory by dragging it out of the window.
+    /// </summary>
+    public static event GenericEventDelegate<DropInventoryItemEventArgs>? DropInventoryItem;
+
+    /// <summary>
+    /// A player drops an item by pressing spacebar on the item in their inventory.
+    /// </summary>
+    public static event GenericEventDelegate<DropItemAtSlotEventArgs>? DropItemAtSlot;
+
+    /// <summary>
+    /// A player dies (afaik only when a player uses "Unstuck" from the menu)
+    /// </summary>
+    public static event GenericEventDelegate<KillEventArgs>? KillEvent;
+
+    /// <summary>
+    /// A player moves all items from one inventory to another.
+    /// </summary>
+    public static event GenericEventDelegate<MoveAllItemsBetweenInventoriesEventArgs>? MoveAllItemsBetweenInventories;
+
+    /// <summary>
+    /// A player moves a single stack of items from one inventory to another.
+    /// </summary>
+    public static event GenericEventDelegate<MoveItemBetweenInventoriesEventArgs>? MoveItemBetweenInventories;
+
+    /// <summary>
+    /// A player moves an object via the build menu.
+    /// </summary>
+    public static event GenericEventDelegate<MoveTileModelEventArgs>? MoveTileModel;
+
+    /// <summary>
+    /// This event is fired when someone attempts to teleports around the map.
+    /// </summary>
+    public static event GenericEventDelegate<PlayerTeleportDebugEventArgs>? PlayerTeleportDebug;
+
+    /// <summary>
+    /// A player requests to sort all items in an inventory.
+    /// </summary>
+    public static event GenericEventDelegate<SortAllItemsEventArgs>? SortAllItems;
+
+    /// <summary>
+    /// A player selects an object in build mode.
+    /// </summary>
+    public static event GenericEventDelegate<StartEditTileModelEventArgs>? StartEditTileModel;
+
+    /// <summary>
+    /// A player stops interacting with an object, eg a chest or workstation.
+    /// </summary>
+    public static event GenericEventDelegate<StopInteractingWithObjectEventArgs>? StopInteractingWithObject;
+
+    /// <summary>
+    /// A client requests authentication with Vivox VOIP Services.
+    /// </summary>
+    public static event GenericEventDelegate<VivoxClientEventArgs>? VivoxClient;
+
+    /// <summary>
+    /// A player interacts with a workstation.
+    /// </summary>
+    public static event GenericEventDelegate<ShareRefinementEventArgs>? ShareRefinement;
+
+    /// <summary>
+    /// A player equips an item.
+    /// </summary>
+    public static event GenericEventDelegate<EquipItemEventArgs>? EquipItem;
+
+    /// <summary>
+    /// A player unequips an item.
+    /// </summary>
+    public static event GenericEventDelegate<UnequipItemEventArgs>? UnequipItem;
+
+    /// <summary>
+    /// A player uses default action (left ctrl) eg, exit shapeshift.
+    /// </summary>
+    public static event GenericEventDelegate<UseDefaultActionEventArgs>? UseDefaultAction;
+
+    /// <summary>
+    /// A player enters a shapeshift form.
+    /// </summary>
+    public static event GenericEventDelegate<EnterShapeshiftEventArgs>? EnterShapeshift;
+
+    /// <summary>
+    /// A player gives up after being downed.
+    /// For some reason this event triggers multiple times if the player holds X for longer.
+    /// </summary>
+    public static event GenericEventDelegate<GiveUpReviveEventArgs>? GiveUpRevive;
+
+    /// <summary>
+    /// A player requests to respawn.
+    /// </summary>
+    public static event GenericEventDelegate<CharacterRespawnEventArgs>? CharacterRespawn;
+
+    /// <summary>
+    /// A player tries to craft an item.
+    /// Also triggers when a player does not have the required materials.
+    /// </summary>
+    public static event GenericEventDelegate<StartCraftItemEventArgs>? StartCraftItem;
+
+    /// <summary>
+    /// A player pressed "Compulsively Count" in their inventory.
+    /// </summary>
+    public static event GenericEventDelegate<SmartMergeItemsBetweenInventoriesEventArgs>? SmartMergeItemsBetweenInventories;
+
+    private static Delegate? GetEventHandler<T>(T e) where T : AbstractEventArgs
+    {
+        return e.GetType().Name switch
+        {
+            nameof(KillEventArgs) => KillEvent,
+            nameof(AdminAuthEventArgs) => AdminAuth,
+            nameof(EquipItemEventArgs) => EquipItem,
+            nameof(ChatMessageEventArgs) => ChatMessage,
+            nameof(DeauthAdminEventArgs) => DeauthAdmin,
+            nameof(UnequipItemEventArgs) => UnequipItem,
+            nameof(VivoxClientEventArgs) => VivoxClient,
+            nameof(GiveUpReviveEventArgs) => GiveUpRevive,
+            nameof(SetMapMarkerEventArgs) => SetMapMarker,
+            nameof(SortAllItemsEventArgs) => SortAllItems,
+            nameof(MoveTileModelEventArgs) => MoveTileModel,
+            nameof(BecomeObserverEventArgs) => BecomeObserver,
+            nameof(BuildTileModelEventArgs) => BuildTileModel,
+            nameof(DropItemAtSlotEventArgs) => DropItemAtSlot,
+            nameof(StartCraftItemEventArgs) => StartCraftItem,
+            nameof(UserKillServerEventArgs) => UserKillServer,
+            nameof(EnterShapeshiftEventArgs) => EnterShapeshift,
+            nameof(ShareRefinementEventArgs) => ShareRefinement,
+            nameof(CharacterRespawnEventArgs) => CharacterRespawn,
+            nameof(UseDefaultActionEventArgs) => UseDefaultAction,
+            nameof(UserDownedServerEventArgs) => UserDownedServer,
+            nameof(DropInventoryItemEventArgs) => DropInventoryItem,
+            nameof(CreateClan_RequestEventArgs) => CreateClan_Request,
+            nameof(StartEditTileModelEventArgs) => StartEditTileModel,
+            nameof(PlayerTeleportDebugEventArgs) => PlayerTeleportDebug,
+            nameof(ActivateVBloodAbilityEventArgs) => ActivateVBloodAbility,
+            nameof(StopInteractingWithObjectEventArgs) => StopInteractingWithObject,
+            nameof(MoveItemBetweenInventoriesEventArgs) => MoveItemBetweenInventories,
+            nameof(MoveAllItemsBetweenInventoriesEventArgs) => MoveAllItemsBetweenInventories,
+            nameof(SmartMergeItemsBetweenInventoriesEventArgs) => SmartMergeItemsBetweenInventories,
+            _ => null
+        };
+    }
+
+    internal static void InvokeEvent<T>(T e) where T : AbstractEventArgs
+    {
+        // Find which delegate takes e as parameter
+        var eventHandler = GetEventHandler(e);
+        if (eventHandler == null) return;
+
+        // Invoke the event handler
+        foreach (var invoker in eventHandler.GetInvocationList())
+        {
+            invoker.DynamicInvoke(e);
+            if (e.Cancelled) return;
+        }
+    }
+}

--- a/Wetstone.csproj
+++ b/Wetstone.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>Wetstone</PackageId>
@@ -19,7 +19,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
 
-    <UnhollowedDllPath>D:\Games\Steam\steamapps\common\VRising\BepInEx\unhollowed</UnhollowedDllPath>
+    <UnhollowedDllPath>D:\steamcmd\steamapps\common\VRisingDedicatedServer\BepInEx\unhollowed</UnhollowedDllPath>
   </PropertyGroup>
 
   <ItemGroup>
@@ -90,5 +90,16 @@
     <Reference Include="Unity.TextMeshPro">
       <HintPath>$(UnhollowedDllPath)\Unity.TextMeshPro.dll</HintPath>
     </Reference>
+
+	  <Reference Include="Unity.Mathematics">
+		  <HintPath>$(UnhollowedDllPath)/Unity.Mathematics.dll</HintPath>
+	  </Reference>
+	  <Reference Include="Unity.Mathematics.Extensions">
+		  <HintPath>$(UnhollowedDllPath)/Unity.Mathematics.Extensions.dll</HintPath>
+	  </Reference>
+	  <Reference Include="Unity.Mathematics.Extensions.Hybrid">
+		  <HintPath>$(UnhollowedDllPath)/Unity.Mathematics.Extensions.Hybrid.dll</HintPath>
+	  </Reference>
+	  
   </ItemGroup>
 </Project>


### PR DESCRIPTION
VRising-netevents project integration ([ https://github.com/AviiNL/vrising-netevents]( https://github.com/AviiNL/vrising-netevents) ) within the wetstone framework.

For this I have integrated all the project files into the Network folder, changed the namespace and modified the `SerializeHook ` and `DeserializeHook  `functions of the `SerializationHooks.cs` file so that if it is not a wetstone message event, it checks against the events recognized by NetEvents