### PR TITLE
Gloomrot update

### DIFF
--- a/API/Keybindings.cs
+++ b/API/Keybindings.cs
@@ -204,9 +204,9 @@ public class Keybinding
         do
         {
             invalid = false;
-            foreach (var entry in Enum.GetValues(typeof(InputFlag)))
+            foreach (var entry in Enum.GetValues<InputFlag>())
             {
-                if (hash == (ulong)entry.GetHashCode())
+                if (hash == (ulong)entry)
                 {
                     invalid = true;
                     hash -= 1;

--- a/API/Keybindings.cs
+++ b/API/Keybindings.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Text.Json;
 using BepInEx;
@@ -200,14 +199,14 @@ public class Keybinding
     private void ComputeInputFlag()
     {
         var idBytes = Encoding.UTF8.GetBytes(Description.Id);
-        var hash = (long)xxHash64.ComputeHash(idBytes, idBytes.Length);
+        var hash = xxHash64.ComputeHash(idBytes, idBytes.Length);
         var invalid = false;
         do
         {
             invalid = false;
-            foreach (var entry in Enum.GetValues(typeof(InputFlag)).Cast<long>())
+            foreach (var entry in Enum.GetValues(typeof(InputFlag)))
             {
-                if (hash == entry)
+                if (hash == (ulong)entry.GetHashCode())
                 {
                     invalid = true;
                     hash -= 1;

--- a/API/VNetwork.cs
+++ b/API/VNetwork.cs
@@ -16,7 +16,7 @@ namespace Wetstone.API;
 public interface VNetworkMessage
 {
     /// <summary>Serialize this value to the given writer.</summary>
-    void Serialize(NetBufferOut writer);
+    void Serialize(ref NetBufferOut writer);
 
     /// <summary>Deserialize values from the given reader and update the current instance.</summary>
     void Deserialize(NetBufferIn reader);

--- a/Features/Reload.cs
+++ b/Features/Reload.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using BepInEx;
-using BepInEx.IL2CPP;
 using BepInEx.Unity.IL2CPP;
 using Mono.Cecil;
 using UnityEngine;

--- a/Features/Reload.cs
+++ b/Features/Reload.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reflection;
 using BepInEx;
 using BepInEx.IL2CPP;
+using BepInEx.Unity.IL2CPP;
 using Mono.Cecil;
 using UnityEngine;
 using Wetstone.API;
@@ -106,7 +107,7 @@ internal static class Reload
         defaultResolver.AddSearchDirectory(_reloadPluginsFolder);
         defaultResolver.AddSearchDirectory(Paths.ManagedPath);
         defaultResolver.AddSearchDirectory(Paths.BepInExAssemblyDirectory);
-        defaultResolver.AddSearchDirectory(Preloader.IL2CPPUnhollowedPath);
+        defaultResolver.AddSearchDirectory(Path.Combine(Paths.BepInExRootPath, "interop"));
 
         using var dll = AssemblyDefinition.ReadAssembly(path, new() { AssemblyResolver = defaultResolver });
         dll.Name.Name = $"{dll.Name.Name}-{DateTime.Now.Ticks}";

--- a/Hooks/Chat.cs
+++ b/Hooks/Chat.cs
@@ -1,15 +1,10 @@
 
 using System;
-using System.Linq;
-using System.Runtime.InteropServices;
-using BepInEx.Unity.IL2CPP.Hook;
 using HarmonyLib;
-using MonoMod.RuntimeDetour;
 using ProjectM;
 using ProjectM.Network;
 using Unity.Entities;
 using Wetstone.API;
-using Wetstone.Util;
 
 namespace Wetstone.Hooks;
 

--- a/Hooks/Chat.cs
+++ b/Hooks/Chat.cs
@@ -18,7 +18,6 @@ public static class Chat
     /// </summary>
     public static event ChatEventHandler? OnChatMessage;
 
-    //private static INativeDetour? Detour;
     private static Harmony? _harmony;
 
     public static unsafe void Initialize()

--- a/Hooks/Chat.cs
+++ b/Hooks/Chat.cs
@@ -54,7 +54,8 @@ public static class Chat
             {
                 OnChatMessage?.Invoke(ev);
 
-                if (ev.Cancelled) return;
+                if (ev.Cancelled)
+                    VWorld.Server.EntityManager.DestroyEntity(entity);
             }
             catch (Exception ex)
             {

--- a/Hooks/Chat.cs
+++ b/Hooks/Chat.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
-using BepInEx.IL2CPP.Hook;
+using MonoMod.RuntimeDetour;
 using ProjectM;
 using ProjectM.Network;
 using Unity.Entities;
@@ -21,7 +21,7 @@ public static class Chat
     /// </summary>
     public static event ChatEventHandler? OnChatMessage;
 
-    private static FastNativeDetour? Detour;
+    private static NativeDetour? Detour;
 
     public static unsafe void Initialize()
     {

--- a/Hooks/Chat.cs
+++ b/Hooks/Chat.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Linq;
 using System.Runtime.InteropServices;
+using BepInEx.Unity.IL2CPP.Hook;
+using HarmonyLib;
 using MonoMod.RuntimeDetour;
 using ProjectM;
 using ProjectM.Network;
@@ -21,53 +23,51 @@ public static class Chat
     /// </summary>
     public static event ChatEventHandler? OnChatMessage;
 
-    private static NativeDetour? Detour;
+    //private static INativeDetour? Detour;
+    private static Harmony? _harmony;
 
     public static unsafe void Initialize()
     {
-        if (Detour != null)
+        if (_harmony != null)
             throw new Exception("Detour already initialized. You don't need to call this. The Wetstone plugin will do it for you.");
 
-        var ty = typeof(ChatMessageSystem).GetNestedTypes().First(x => x.Name.Contains("ChatMessageJob"));
-        Detour = NativeHookUtil.Detour(ty, "OriginalLambdaBody", Hook, out Original);
+        _harmony = Harmony.CreateAndPatchAll(typeof(Chat));
     }
 
     public static unsafe void Uninitialize()
     {
-        if (Detour == null)
+        if (_harmony == null)
             throw new Exception("Detour wasn't initialized. Are you trying to unload Wetstone twice?");
 
-        Detour.Dispose();
-        Detour = null;
-
-        OnChatMessage = null;
+        _harmony.UnpatchSelf();
     }
 
-    private static unsafe void Hook(IntPtr _this, Entity* chatMessageEntity, ChatMessageEvent* chatMessage, FromCharacter* fromCharacter)
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(ChatMessageSystem), nameof(ChatMessageSystem.OnUpdate))]
+    public static void OnUpdatePrefix(ChatMessageSystem __instance)
     {
-        var ev = new VChatEvent(fromCharacter->User, fromCharacter->Character, chatMessage->MessageText.ToString(), chatMessage->MessageType);
-
-        WetstonePlugin.Logger.LogInfo($"[Chat] [{ev.Type}] {ev.User.CharacterName}: {ev.Message}");
-
-        try
+        var entities = __instance._ChatMessageQuery.ToEntityArray(Unity.Collections.Allocator.Temp);
+        foreach (var entity in entities)
         {
-            OnChatMessage?.Invoke(ev);
+            var chatMessage = VWorld.Server.EntityManager.GetComponentData<ChatMessageEvent>(entity);
+            var fromCharacter = VWorld.Server.EntityManager.GetComponentData<FromCharacter>(entity);
+            var ev = new VChatEvent(fromCharacter.User, fromCharacter.Character, chatMessage.MessageText.ToString(), chatMessage.MessageType);
 
-            if (ev.Cancelled) return;
-        }
-        catch (Exception ex)
-        {
-            WetstonePlugin.Logger.LogError("Error dispatching chat event:");
-            WetstonePlugin.Logger.LogError(ex);
-        }
+            WetstonePlugin.Logger.LogInfo($"[Chat] [{ev.Type}] {ev.User.CharacterName}: {ev.Message}");
 
-        Original!(_this, chatMessageEntity, chatMessage, fromCharacter);
+            try
+            {
+                OnChatMessage?.Invoke(ev);
+
+                if (ev.Cancelled) return;
+            }
+            catch (Exception ex)
+            {
+                WetstonePlugin.Logger.LogError("Error dispatching chat event:");
+                WetstonePlugin.Logger.LogError(ex);
+            }
+        }
     }
-
-    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public unsafe delegate void OriginalLambdaBody(IntPtr _this, Entity* chatMessageEntity, ChatMessageEvent* chatMessage, FromCharacter* fromCharacter);
-
-    private static OriginalLambdaBody? Original;
 }
 
 /// <summary>

--- a/Hooks/GameFrame.cs
+++ b/Hooks/GameFrame.cs
@@ -1,5 +1,5 @@
+using Il2CppInterop.Runtime.Injection;
 using System;
-using UnhollowerRuntimeLib;
 using UnityEngine;
 
 namespace Wetstone.Hooks;

--- a/Hooks/Keybindings.cs
+++ b/Hooks/Keybindings.cs
@@ -2,6 +2,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BepInEx.Unity.IL2CPP.Hook;
 using HarmonyLib;
 using MonoMod.RuntimeDetour;
 using ProjectM;
@@ -36,7 +37,7 @@ static class Keybindings
 #nullable disable
     private static TryGetInputFlagLocalization_t TryGetInputFlagLocalization_Original;
     private static Harmony _harmony;
-    private static NativeDetour _detour;
+    private static INativeDetour _detour;
 #nullable enable
 
     public static void Initialize()

--- a/Hooks/Keybindings.cs
+++ b/Hooks/Keybindings.cs
@@ -2,11 +2,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using BepInEx.IL2CPP.Hook;
 using HarmonyLib;
+using MonoMod.RuntimeDetour;
 using ProjectM;
 using ProjectM.UI;
-using StunLocalization;
+using Stunlock.Localization;
 using StunShared.UI;
 using TMPro;
 using UnityEngine;
@@ -36,7 +36,7 @@ static class Keybindings
 #nullable disable
     private static TryGetInputFlagLocalization_t TryGetInputFlagLocalization_Original;
     private static Harmony _harmony;
-    private static FastNativeDetour _detour;
+    private static NativeDetour _detour;
 #nullable enable
 
     public static void Initialize()
@@ -189,7 +189,7 @@ static class Keybindings
 
         if (customKeybinding != null)
         {
-            *key = new LocalizationKey(new ProjectM.AssetGuid(customKeybinding.AssetGuid, 0, 0, 0));
+            *key = new LocalizationKey(new ProjectM.AssetGuid() { _a = customKeybinding.AssetGuid });
             return true;
         }
 

--- a/Hooks/OnInitialize.cs
+++ b/Hooks/OnInitialize.cs
@@ -1,5 +1,6 @@
 
 using BepInEx.IL2CPP;
+using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
 using Wetstone.API;
 

--- a/Hooks/OnInitialize.cs
+++ b/Hooks/OnInitialize.cs
@@ -1,5 +1,3 @@
-
-using BepInEx.IL2CPP;
 using BepInEx.Unity.IL2CPP;
 using HarmonyLib;
 using Wetstone.API;

--- a/Network/BlittableNetworkMessage.cs
+++ b/Network/BlittableNetworkMessage.cs
@@ -41,7 +41,7 @@ where T : unmanaged
         }
     }
 
-    public void Serialize(NetBufferOut writer)
+    public void Serialize(ref NetBufferOut writer)
     {
         unsafe
         {

--- a/Network/CustomNetworkEvent.cs
+++ b/Network/CustomNetworkEvent.cs
@@ -1,5 +1,6 @@
+using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.Injection;
 using Stunlock.Network;
-using UnhollowerRuntimeLib;
 using Unity.Entities;
 using Wetstone.API;
 
@@ -36,7 +37,7 @@ internal class CustomNetworkEvent : Il2CppSystem.Object
     }
 
     // Serialize the entire event to the net writer, except event ID.
-    internal void Serialize(NetBufferOut netBuffer)
+    internal void Serialize(ref NetBufferOut netBuffer)
     {
         if (Message == null)
             throw new System.Exception("Tried to serialize a CustomNetworkEvent with no message");
@@ -46,7 +47,7 @@ internal class CustomNetworkEvent : Il2CppSystem.Object
 
         try
         {
-            Message.Serialize(netBuffer);
+            Message.Serialize(ref netBuffer);
         }
         catch (System.Exception ex)
         {
@@ -60,7 +61,7 @@ internal class CustomNetworkEvent : Il2CppSystem.Object
     {
         ClassInjector.RegisterTypeInIl2Cpp(typeof(CustomNetworkEvent));
 
-        var il2cppty = UnhollowerRuntimeLib.Il2CppType.From(typeof(CustomNetworkEvent));
+        var il2cppty = Il2CppType.From(typeof(CustomNetworkEvent));
 
         if (TypeManager.FindTypeIndex(il2cppty) == -1)
         {

--- a/Network/SerializationHooks.cs
+++ b/Network/SerializationHooks.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Runtime.InteropServices;
 using BepInEx.Unity.IL2CPP.Hook;
-using MonoMod.RuntimeDetour;
 using ProjectM.Network;
 using Stunlock.Network;
 using Unity.Collections;

--- a/Network/SerializationHooks.cs
+++ b/Network/SerializationHooks.cs
@@ -38,11 +38,11 @@ internal static class SerializationHooks
     }
 
     [UnmanagedFunctionPointer(CallingConvention.StdCall)]
-    public unsafe delegate void SerializeEvent(IntPtr entityManager, NetworkEventType networkEventType, ref NetBufferOut netBufferOut, IntPtr entity);
+    public unsafe delegate void SerializeEvent(IntPtr entityManager, NetworkEventType networkEventType, ref NetBufferOut netBufferOut, Entity entity);
 
     public static SerializeEvent? SerializeOriginal;
 
-    public unsafe static void SerializeHook(IntPtr entityManager, NetworkEventType networkEventType, ref NetBufferOut netBufferOut, IntPtr entity)
+    public unsafe static void SerializeHook(IntPtr entityManager, NetworkEventType networkEventType, ref NetBufferOut netBufferOut, Entity entity)
     {
         // if this is not a custom event, just call the original function
         if (networkEventType.EventId != SerializationHooks.WETSTONE_NETWORK_EVENT_ID)
@@ -52,8 +52,7 @@ internal static class SerializationHooks
         }
 
         // extract the custom network event
-        var realEntity = *(Entity*)&entity;
-        var data = (CustomNetworkEvent)VWorld.Server.EntityManager.GetComponentObject<Il2CppSystem.Object>(realEntity, CustomNetworkEvent.ComponentType);
+        var data = (CustomNetworkEvent)VWorld.Server.EntityManager.GetComponentObject<Il2CppSystem.Object>(entity, CustomNetworkEvent.ComponentType);
 
         // write out the event ID and the data
         netBufferOut.Write((uint)SerializationHooks.WETSTONE_NETWORK_EVENT_ID);

--- a/Util/Il2CppMethodResolver.cs
+++ b/Util/Il2CppMethodResolver.cs
@@ -2,9 +2,9 @@ using System;
 using System.IO;
 using System.Reflection;
 using Iced.Intel;
-using UnhollowerBaseLib;
-using UnhollowerBaseLib.Runtime;
-using UnhollowerBaseLib.Runtime.VersionSpecific.MethodInfo;
+using Il2CppInterop.Common;
+using Il2CppInterop.Runtime.Runtime;
+using Il2CppInterop.Runtime.Runtime.VersionSpecific.MethodInfo;
 
 namespace Wetstone.Util;
 
@@ -65,7 +65,7 @@ public class Il2CppMethodResolver
 
     public static unsafe IntPtr ResolveFromMethodInfo(MethodInfo method)
     {
-        var methodInfoField = UnhollowerUtils.GetIl2CppMethodInfoPointerFieldForGeneratedMethod(method);
+        var methodInfoField = Il2CppInteropUtils.GetIl2CppMethodInfoPointerFieldForGeneratedMethod(method);
         if (methodInfoField == null)
             throw new Exception($"Couldn't obtain method info for {method}");
 

--- a/Util/NativeHookUtil.cs
+++ b/Util/NativeHookUtil.cs
@@ -1,45 +1,24 @@
 using BepInEx.Unity.IL2CPP.Hook;
 using HarmonyLib;
-using MonoMod.RuntimeDetour;
 using System;
 using System.Reflection;
-using System.Runtime.InteropServices;
 
 namespace Wetstone.Util;
 
 public static class NativeHookUtil
 {
-    public static NativeDetour Detour<T>(string typeName, string methodName, T to, out T original) where T : System.Delegate?
+    public static INativeDetour Detour<T>(string typeName, string methodName, T to, out T original) where T : System.Delegate?
     {
         return Detour(Type.GetType(typeName), methodName, to, out original);
     }
 
-    public static NativeDetour Detour<T>(Type type, string methodName, T to, out T original) where T : System.Delegate?
+    public static INativeDetour Detour<T>(Type type, string methodName, T to, out T original) where T : System.Delegate?
     {
         var method = type.GetMethod(methodName, AccessTools.all);
         return Detour(method, to, out original);
     }
 
-    public static NativeDetour Detour<T>(MethodInfo method, T to, out T original) where T : System.Delegate?
-    {
-        var address = Il2CppMethodResolver.ResolveFromMethodInfo(method);
-        WetstonePlugin.Logger.LogInfo($"Detouring {method.DeclaringType?.FullName}.{method.Name} at {address.ToString("X")}");
-        var detour = new NativeDetour(address, Marshal.GetFunctionPointerForDelegate(to));
-        original = detour.GenerateTrampoline<T>();
-        return detour;
-    }
-    public static INativeDetour IDetour<T>(string typeName, string methodName, T to, out T original) where T : System.Delegate?
-    {
-        return IDetour(Type.GetType(typeName), methodName, to, out original);
-    }
-
-    public static INativeDetour IDetour<T>(Type type, string methodName, T to, out T original) where T : System.Delegate?
-    {
-        var method = type.GetMethod(methodName, AccessTools.all);
-        return IDetour(method, to, out original);
-    }
-
-    public static INativeDetour IDetour<T>(MethodInfo method, T to, out T original) where T : System.Delegate?
+    public static INativeDetour Detour<T>(MethodInfo method, T to, out T original) where T : System.Delegate?
     {
         var address = Il2CppMethodResolver.ResolveFromMethodInfo(method);
         WetstonePlugin.Logger.LogInfo($"Detouring {method.DeclaringType?.FullName}.{method.Name} at {address.ToString("X")}");

--- a/Util/NativeHookUtil.cs
+++ b/Util/NativeHookUtil.cs
@@ -1,28 +1,48 @@
-
+using BepInEx.Unity.IL2CPP.Hook;
+using HarmonyLib;
+using MonoMod.RuntimeDetour;
 using System;
 using System.Reflection;
-using BepInEx.IL2CPP.Hook;
-using HarmonyLib;
+using System.Runtime.InteropServices;
 
 namespace Wetstone.Util;
 
 public static class NativeHookUtil
 {
-    public static FastNativeDetour Detour<T>(string ty, string methodName, T to, out T original) where T : System.Delegate?
+    public static NativeDetour Detour<T>(string typeName, string methodName, T to, out T original) where T : System.Delegate?
     {
-        return Detour(Type.GetType(ty), methodName, to, out original);
+        return Detour(Type.GetType(typeName), methodName, to, out original);
     }
 
-    public static FastNativeDetour Detour<T>(Type ty, string methodName, T to, out T original) where T : System.Delegate?
+    public static NativeDetour Detour<T>(Type type, string methodName, T to, out T original) where T : System.Delegate?
     {
-        var method = ty.GetMethod(methodName, AccessTools.all);
+        var method = type.GetMethod(methodName, AccessTools.all);
         return Detour(method, to, out original);
     }
 
-    public static FastNativeDetour Detour<T>(MethodInfo method, T to, out T original) where T : System.Delegate?
+    public static NativeDetour Detour<T>(MethodInfo method, T to, out T original) where T : System.Delegate?
     {
         var address = Il2CppMethodResolver.ResolveFromMethodInfo(method);
-        WetstonePlugin.Logger.LogInfo($"Detouring {method.DeclaringType.FullName}.{method.Name} at {address.ToString("X")}");
-        return FastNativeDetour.CreateAndApply(address, to, out original);
+        WetstonePlugin.Logger.LogInfo($"Detouring {method.DeclaringType?.FullName}.{method.Name} at {address.ToString("X")}");
+        var detour = new NativeDetour(address, Marshal.GetFunctionPointerForDelegate(to));
+        original = detour.GenerateTrampoline<T>();
+        return detour;
+    }
+    public static INativeDetour IDetour<T>(string typeName, string methodName, T to, out T original) where T : System.Delegate?
+    {
+        return IDetour(Type.GetType(typeName), methodName, to, out original);
+    }
+
+    public static INativeDetour IDetour<T>(Type type, string methodName, T to, out T original) where T : System.Delegate?
+    {
+        var method = type.GetMethod(methodName, AccessTools.all);
+        return IDetour(method, to, out original);
+    }
+
+    public static INativeDetour IDetour<T>(MethodInfo method, T to, out T original) where T : System.Delegate?
+    {
+        var address = Il2CppMethodResolver.ResolveFromMethodInfo(method);
+        WetstonePlugin.Logger.LogInfo($"Detouring {method.DeclaringType?.FullName}.{method.Name} at {address.ToString("X")}");
+        return INativeDetour.CreateAndApply(address, to, out original);
     }
 }

--- a/Wetstone.csproj
+++ b/Wetstone.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <PackageId>Wetstone</PackageId>
@@ -7,14 +7,14 @@
 
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
 
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <AssemblyName>Wetstone</AssemblyName>
     <Description>Plugin framework and general utilities for V Rising mods.</Description>
 
     <BepInExPluginGuid>xyz.molenzwiebel.wetstone</BepInExPluginGuid>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
@@ -23,19 +23,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BepInEx.IL2CPP" Version="6.0.0-*" IncludeAssets="compile" />
-    <PackageReference Include="BepInEx.PluginInfoProps" Version="1.*" />
-    <PackageReference Include="iced" Version="1.17.0" />
+    <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" />
+    <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" />
+    <PackageReference Include="Iced" Version="1.18.0" />
     <PackageReference Include="Standart.Hash.xxHash" Version="3.1.0">
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="System.Text.Json" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Costura.Fody" Version="5.7.0">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Fody" Version="6.6.2" />
+    <PackageReference Include="System.Text.Json" Version="6.0.7" />
   </ItemGroup>
 
   <ItemGroup>
@@ -55,8 +53,8 @@
       <HintPath>$(UnhollowedDllPath)\com.stunlock.network.dll</HintPath>
     </Reference>
 
-    <Reference Include="UnityEngine.InputLegacyModule.dll">
-      <HintPath>$(UnhollowedDllPath)\UnityEngine.InputLegacyModule.dll</HintPath>
+    <Reference Include="Stunlock.Localization">
+      <HintPath>..\BepInEx\unhollowed\Stunlock.Localization.dll</HintPath>
     </Reference>
 
     <Reference Include="Unity.Collections">

--- a/Wetstone.csproj
+++ b/Wetstone.csproj
@@ -18,11 +18,10 @@
 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
-
-    <UnhollowedDllPath>D:\Games\Steam\steamapps\common\VRising\BepInEx\unhollowed</UnhollowedDllPath>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="VRising.Unhollowed.Client" Version="0.6.0.57108*" />
     <PackageReference Include="BepInEx.Unity.IL2CPP" Version="6.0.0-be.*" IncludeAssets="compile" />
     <PackageReference Include="BepInEx.PluginInfoProps" Version="2.1.0" />
     <PackageReference Include="Iced" Version="1.18.0" />
@@ -34,59 +33,5 @@
     </PackageReference>
     <PackageReference Include="Fody" Version="6.6.2" />
     <PackageReference Include="System.Text.Json" Version="6.0.7" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="ProjectM.Shared">
-      <HintPath>$(UnhollowedDllPath)\ProjectM.Shared.dll</HintPath>
-    </Reference>
-
-    <Reference Include="IL2Cppmscorlib">
-      <HintPath>$(UnhollowedDllPath)\Il2Cppmscorlib.dll</HintPath>
-    </Reference>
-
-    <Reference Include="ProjectM">
-      <HintPath>$(UnhollowedDllPath)\ProjectM.dll</HintPath>
-    </Reference>
-
-    <Reference Include="com.stunlock.network">
-      <HintPath>$(UnhollowedDllPath)\com.stunlock.network.dll</HintPath>
-    </Reference>
-
-    <Reference Include="Stunlock.Localization">
-      <HintPath>..\BepInEx\unhollowed\Stunlock.Localization.dll</HintPath>
-    </Reference>
-
-    <Reference Include="Unity.Collections">
-      <HintPath>$(UnhollowedDllPath)\Unity.Collections.dll</HintPath>
-    </Reference>
-
-    <Reference Include="Unity.Entities">
-      <HintPath>$(UnhollowedDllPath)\Unity.Entities.dll</HintPath>
-    </Reference>
-
-    <Reference Include="ProjectM.HUD">
-      <HintPath>$(UnhollowedDllPath)\ProjectM.HUD.dll</HintPath>
-    </Reference>
-
-    <Reference Include="UnityEngine.CoreModule">
-      <HintPath>$(UnhollowedDllPath)\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-
-    <Reference Include="ProjectM.CodeGeneration">
-      <HintPath>$(UnhollowedDllPath)\ProjectM.CodeGeneration.dll</HintPath>
-    </Reference>
-
-    <Reference Include="UnityEngine.InputLegacyModule">
-      <HintPath>$(UnhollowedDllPath)\UnityEngine.InputLegacyModule.dll</HintPath>
-    </Reference>
-
-    <Reference Include="Stunlock.Core">
-      <HintPath>$(UnhollowedDllPath)\Stunlock.Core.dll</HintPath>
-    </Reference>
-
-    <Reference Include="Unity.TextMeshPro">
-      <HintPath>$(UnhollowedDllPath)\Unity.TextMeshPro.dll</HintPath>
-    </Reference>
   </ItemGroup>
 </Project>

--- a/WetstonePlugin.cs
+++ b/WetstonePlugin.cs
@@ -1,12 +1,12 @@
 ﻿using BepInEx;
 using BepInEx.Configuration;
-using BepInEx.IL2CPP;
 using BepInEx.Logging;
+using BepInEx.Unity.IL2CPP;
 using Wetstone.API;
 
 namespace Wetstone
 {
-    [BepInPlugin(PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
+    [BepInPlugin(MyPluginInfo.PLUGIN_GUID, MyPluginInfo.PLUGIN_NAME, MyPluginInfo.PLUGIN_VERSION)]
     public class WetstonePlugin : BasePlugin
     {
 #nullable disable
@@ -46,7 +46,7 @@ namespace Wetstone
             Hooks.GameFrame.Initialize();
             Network.SerializationHooks.Initialize();
 
-            Logger.LogInfo($"Wetstone v{PluginInfo.PLUGIN_VERSION} loaded.");
+            Logger.LogInfo($"Wetstone v{MyPluginInfo.PLUGIN_VERSION} loaded.");
 
             // NOTE: MUST BE LAST. This initializes plugins that depend on our state being set up.
             if (VWorld.IsClient || _enableReloadCommand.Value)


### PR DESCRIPTION
Updated to work with Gloomrot update.

Chat hook was re-written to manually process messages via OnUpdate because I was unable to get the hook into the ChatMessageJob OriginalLambdaBody to work. I think this is due to the ChatMessageJob being a struct now instead of a class.